### PR TITLE
fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ yarn-error.log*
 # env files
 .env
 .env.development
-.ent.test
+.env.test
 .env*.local
 
 # Stores VSCode versions used for testing VSCode extensions

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import { ToastContainer } from 'react-toastify';
 import StepForm from '@/components/Form/StepForm';
 import EmailForm from '@/components/Form/EmailForm';
 import EmailVerifyForm from '@/components/Form/EmailVerifyForm';
@@ -19,15 +20,25 @@ export const metadata: Metadata = {
 
 export default function Signup() {
   return (
-    <StepForm>
-      <EmailForm />
-      <EmailVerifyForm />
-      <PasswordForm />
-      <NameForm />
-      <TermsForm />
-      <SymbolForm skipable buttonText="다음" />
-      <CategoryForm skipable buttonText="다음" />
-      <CompleteSignup hideHeader />
-    </StepForm>
+    <>
+      <StepForm>
+        <EmailForm />
+        <EmailVerifyForm />
+        <PasswordForm />
+        <NameForm />
+        <TermsForm />
+        <SymbolForm skipable buttonText="다음" />
+        <CategoryForm skipable buttonText="다음" />
+        <CompleteSignup hideHeader />
+      </StepForm>
+      <ToastContainer
+        position="bottom-center"
+        autoClose={3000}
+        hideProgressBar
+        newestOnTop={true}
+        pauseOnFocusLoss={false}
+        pauseOnHover={false}
+      />
+    </>
   );
 }

--- a/src/components/Form/CategoryForm/index.tsx
+++ b/src/components/Form/CategoryForm/index.tsx
@@ -7,6 +7,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { throttle } from 'lodash';
 import { ToastContainer } from 'react-toastify';
 import { initLikedCategoryMap, initSelectedCategoryMap, reset, useCategoryList } from '@/redux/slice/categorySlice';
+import MuiSpinner from '@/components/UI/Spinner/MuiSpinner';
 import { SearchCategory, SearchCategoryResult, SelectedCategoryHorizonList } from '@/components/Search/SearchCategory';
 import Button from '@/components/Button/Button';
 import { LockNotification } from '@/components/Notification';
@@ -211,9 +212,16 @@ function CategoryForm({ buttonText = '선택 완료' }: CategoryFormProps) {
               bgColorTheme="orange"
               textColorTheme="white"
               fullWidth
-              className="disabled:!cursor-progress disabled:!bg-slate-400"
+              className="relative disabled:!cursor-progress disabled:!bg-slate-300 disabled:!opacity-60"
             >
-              {likeStatus === 'loading' || unlikeStatus === 'loading' ? '요청처리 중' : buttonText}
+              {likeStatus === 'loading' || unlikeStatus === 'loading' ? (
+                <div className="absolute left-0 top-0 flex h-full w-full items-center justify-center">
+                  <div className="translate-y-[3.4px]">
+                    <MuiSpinner />
+                  </div>
+                </div>
+              ) : null}
+              {buttonText}
             </Button>
           </div>
         </div>

--- a/src/components/Form/LoginForm/index.tsx
+++ b/src/components/Form/LoginForm/index.tsx
@@ -77,7 +77,7 @@ function LoginForm({ continueURL }: LoginFormProps) {
       queryClient.removeQueries({ queryKey: ['auth'] });
       queryClient.invalidateQueries(['profile']);
 
-      router.push(continueURL ?? '/');
+      router.replace(continueURL ?? '/');
 
       return;
     } catch (error) {

--- a/src/components/Form/PasswordForm/index.tsx
+++ b/src/components/Form/PasswordForm/index.tsx
@@ -19,7 +19,7 @@ function PasswordForm() {
     handleSubmit,
     done,
     getValues,
-    formState: { isValid },
+    formState: { errors, isValid },
   } = useFormContext() as UseStepFormContext<PasswordForm>;
 
   const title = `
@@ -36,40 +36,46 @@ function PasswordForm() {
       <FormTitle title={title} />
       <div className="space-y-6">
         <ReadOnlyInput fieldName="email" />
-        <PasswordInput
-          placeholder="비밀번호"
-          {...register('password', {
-            required: '비밀번호를 입력해주세요',
-            validate(value) {
-              const { result, type } = validatePassword(value);
+        <div className="space-y-2">
+          <PasswordInput
+            placeholder="비밀번호"
+            {...register('password', {
+              required: '비밀번호를 입력해주세요',
+              validate(value) {
+                const { result, type } = validatePassword(value);
 
-              if (result === true) return true;
+                if (result === true) return true;
 
-              if (type === 'passwordLength') return '패스워드는 8자 이상, 16자 이하입니다';
-              if (type === 'notAllowedChar') return '패스워드는 영문 대소문자, 0-9 숫자로 구성되어야 합니다';
-              if (type === 'NotContainSpecial') return '최소 1개 이상의 특수문자가 포함되어야 합니다';
+                if (type === 'passwordLength') return '패스워드는 8자 이상, 16자 이하입니다';
+                if (type === 'notAllowedChar') return '패스워드는 영문 대소문자, 0-9 숫자로 구성되어야 합니다';
+                if (type === 'NotContainSpecial') return '최소 1개 이상의 특수문자가 포함되어야 합니다';
 
-              return '유효하지 않은 비밀번호입니다';
-            },
-          })}
-        />
-        <PasswordInput
-          placeholder="비밀번호 확인"
-          {...register('passwordCheck', {
-            required: '비밀번호 확인을 입력해주세요',
-            validate(value) {
-              return getValues().password === value ? true : '입력한 비밀번호와 같지 않습니다';
-            },
-          })}
-        />
+                return '유효하지 않은 비밀번호입니다';
+              },
+            })}
+          />
+          {errors?.password ? <div className="text-xs text-error">{errors.password.message}</div> : null}
+        </div>
+        <div className="space-y-2">
+          <PasswordInput
+            placeholder="비밀번호 확인"
+            {...register('passwordCheck', {
+              required: '비밀번호 확인을 입력해주세요',
+              validate(value) {
+                return getValues().password === value ? true : '입력한 비밀번호와 같지 않습니다';
+              },
+            })}
+          />
+          {errors?.passwordCheck ? <div className="text-xs text-error">{errors.passwordCheck.message}</div> : null}
+        </div>
       </div>
       <Button
         type="submit"
-        sizeTheme="fullWidth"
         className="mt-8 font-bold disabled:!cursor-default disabled:!bg-[#DBDEE1]"
         bgColorTheme="orange"
         textColorTheme="white"
         disabled={!isValid}
+        fullWidth
       >
         다음
       </Button>

--- a/src/components/Form/SymbolForm/index.tsx
+++ b/src/components/Form/SymbolForm/index.tsx
@@ -2,11 +2,13 @@
 
 import { useLayoutEffect, useState, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
+import { HttpStatusCode } from 'axios';
 import { useFormContext } from 'react-hook-form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { throttle } from 'lodash';
 import { ToastContainer } from 'react-toastify';
 import { initLikedSymbolMap, initSelectedSymbolMap, reset, useSymbolList } from '@/redux/slice/symbolSlice';
+import MuiSpinner from '@/components/UI/Spinner/MuiSpinner';
 import Button from '@/components/Button/Button';
 import { SearchSymbol, SelectedSymbolHorizonList, SearchSymbolResult } from '@/components/Search/SearchSymbol';
 import { LockNotification } from '@/components/Notification';
@@ -192,7 +194,7 @@ function SymbolForm({ buttonText = '선택 완료' }: SymbolFormProps) {
   useLayoutEffect(() => {
     if (authStatus === 'Pending' || authStatus === 'Loading' || likedSymbolStatus === 'loading') return;
 
-    if (authStatus !== 'AuthUser' || likedSymbolStatus === 'error' || likedSymbolList.status !== 200) {
+    if (authStatus !== 'AuthUser' || likedSymbolStatus === 'error' || likedSymbolList.status !== HttpStatusCode.Ok) {
       push('/login?continueURL=/mypage/edit/symbol');
 
       return;
@@ -272,9 +274,16 @@ function SymbolForm({ buttonText = '선택 완료' }: SymbolFormProps) {
               bgColorTheme="orange"
               textColorTheme="white"
               fullWidth
-              className="disabled:!cursor-progress disabled:!bg-slate-400"
+              className="relative disabled:!cursor-progress disabled:!bg-slate-300 disabled:!opacity-60"
             >
-              {likeStatus === 'loading' || unlikeStatus === 'loading' ? '요청처리 중' : buttonText}
+              {likeStatus === 'loading' || unlikeStatus === 'loading' ? (
+                <div className="absolute left-0 top-0 flex h-full w-full items-center justify-center">
+                  <div className="translate-y-[3.4px]">
+                    <MuiSpinner />
+                  </div>
+                </div>
+              ) : null}
+              {buttonText}
             </Button>
           </div>
         </div>

--- a/src/components/NewsDetail/AddCategoryForm.tsx
+++ b/src/components/NewsDetail/AddCategoryForm.tsx
@@ -7,6 +7,8 @@ import { disLikeCategory, getAllCategory, getLikeCategory, likeCategory } from '
 import { toastNotify } from '@/util/toastNotify';
 import { type Category } from '@/interfaces/Category';
 import { type OnChipChangeResult } from '../UI/Chip/SymbolChip';
+import { AxiosError, HttpStatusCode } from 'axios';
+import { APIResponse } from '@/interfaces/Dto/Core';
 
 interface AddCategoryFormProps {
   category?: Category;
@@ -46,8 +48,23 @@ function AddCategoryForm({ category }: AddCategoryFormProps) {
     onSuccess() {
       toastNotify('success', '관심 카테고리 생성 성공');
     },
-    onError() {
-      setLiked(!!isLike());
+    onError(error) {
+      if (error instanceof AxiosError) {
+        const { response } = error as AxiosError<APIResponse<string & { key?: string; value?: string }>>;
+
+        if (response?.data.status === HttpStatusCode.BadRequest) {
+          if (response.data.data?.key === 'benefit') {
+            toastNotify('error', '구독 후 4개 이상의 관심 카테고리 설정이 가능합니다.');
+
+            return;
+          }
+        }
+
+        toastNotify('error', '관심 카테고리 생성 실패');
+
+        return;
+      }
+
       toastNotify('error', '관심 카테고리 생성 실패');
     },
     onSettled() {

--- a/src/components/SetInterestsModal/index.tsx
+++ b/src/components/SetInterestsModal/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { MdClear } from 'react-icons/md';
 import CategoryAccordion from '../Accordion/CategoryAccordion';
 import SymbolAccordion from '../Accordion/SymbolAccordion';
@@ -10,6 +10,12 @@ interface SetInterestModalProps {
 }
 
 function SetInterestModal({ onClose }: SetInterestModalProps) {
+  useEffect(() => {
+    return () => {
+      document.body.classList.remove('!overflow-hidden');
+    };
+  }, []);
+
   return (
     <div className="fixed_inner fixed top-0 z-10 h-screen overflow-auto bg-white">
       <div className="box-border px-4">

--- a/src/components/UI/Chip/CategoryChip.tsx
+++ b/src/components/UI/Chip/CategoryChip.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { MdGrid3X3 } from 'react-icons/md';
 import { AppIcons } from '@/components/Icons';
 import { type Category } from '@/interfaces/Category';
@@ -25,7 +25,6 @@ function CategoryChip({
   onChange,
   onClose,
 }: CategoryChipProps) {
-  const [checked, setChecked] = useState(selected);
   const [isRender, setIsRender] = useState(true);
   const changeTrigger = useRef<boolean>(false);
 
@@ -35,19 +34,11 @@ function CategoryChip({
 
       changeTrigger.current = true;
 
-      const { status } = await onChange();
+      await onChange();
 
       changeTrigger.current = false;
-
-      if (status === 'success') {
-        setChecked((prev) => !prev);
-      }
     }
   };
-
-  useEffect(() => {
-    setChecked(!!selected);
-  }, [selected]);
 
   if (loading) {
     return showHashTagIcon ? (
@@ -85,9 +76,9 @@ function CategoryChip({
       className={`box-border inline-flex h-9 w-max ${
         showHashTagIcon ? 'min-w-[84px]' : ''
       } max-w-sm shrink-0 cursor-pointer select-none items-center justify-between rounded-full border px-3.5 py-2 align-top transition-transform ${
-        checked ? 'border-[#FC954A] bg-[#FFF0E4]' : 'border-[#E5E7EC] bg-white'
+        selected ? 'border-[#FC954A] bg-[#FFF0E4]' : 'border-[#E5E7EC] bg-white'
       } ${shadowEffect ? 'my-2.5 ml-[9px]' : 'm-0'} ${
-        checked && shadowEffect ? 'shadow-[0_0_15px_0_rgba(252,149,74,0.3)]' : 'shadow-none'
+        selected && shadowEffect ? 'shadow-[0_0_15px_0_rgba(252,149,74,0.3)]' : 'shadow-none'
       }`}
       onClick={handleClick}
     >

--- a/src/components/UI/Chip/SymbolChip.tsx
+++ b/src/components/UI/Chip/SymbolChip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import SymbolLogoImage from '@/components/Image/SymbolLogoImage';
 import { AppIcons } from '@/components/Icons';
 import { DeltaPriceColor, DeltaPriceType, getPriceInfo } from '@/util/chart';
@@ -32,7 +32,6 @@ function SymbolChip({
   onChange,
   onClose,
 }: SymbolChipProps) {
-  const [checked, setChecked] = useState(selected);
   const [isRender, setIsRender] = useState(true);
   const changeTrigger = useRef<boolean>(false);
 
@@ -47,19 +46,11 @@ function SymbolChip({
 
       changeTrigger.current = true;
 
-      const { status } = await onChange();
+      await onChange();
 
       changeTrigger.current = false;
-
-      if (status === 'success') {
-        setChecked((prev) => !prev);
-      }
     }
   };
-
-  useEffect(() => {
-    setChecked(!!selected);
-  }, [selected]);
 
   if (loading) {
     return (
@@ -77,9 +68,9 @@ function SymbolChip({
   return (symbol?.symbol || symbol?.name) && isRender ? (
     <div
       className={`box-border inline-flex h-9 w-max max-w-sm shrink-0 cursor-pointer select-none items-center justify-between rounded-full border px-3.5 py-2 align-top ${
-        checked ? 'border-[#FC954A] bg-[#FFF0E4]' : 'border-[#E5E7EC] bg-white'
+        selected ? 'border-[#FC954A] bg-[#FFF0E4]' : 'border-[#E5E7EC] bg-white'
       } ${shadowEffect ? 'my-2.5 ml-[9px]' : 'm-0'} ${
-        checked && shadowEffect ? 'shadow-[0_0_15px_0_rgba(252,149,74,0.3)]' : 'shadow-none'
+        selected && shadowEffect ? 'shadow-[0_0_15px_0_rgba(252,149,74,0.3)]' : 'shadow-none'
       }`}
       onClick={handleClick}
     >

--- a/src/service/user.ts
+++ b/src/service/user.ts
@@ -61,12 +61,13 @@ export async function updateUserInfo({
     ...(typeof newsLetter === 'boolean' && { newsLetter }),
   } as UpdateUserInfoRequest;
 
-  const updateUserInfoResponse = await axiosInstance.post<any, UpdateUserInfoResponse, UpdateUserInfoRequest>(
-    '/api/auth/user',
-    {
-      ...postPayload,
-    },
-  );
+  const updateUserInfoResponse = await axiosInstance.post<
+    any,
+    AxiosResponse<UpdateUserInfoResponse>,
+    UpdateUserInfoRequest
+  >('/api/auth/user', {
+    ...postPayload,
+  });
 
   return updateUserInfoResponse;
 }

--- a/src/util/url.ts
+++ b/src/util/url.ts
@@ -4,6 +4,7 @@ interface URLConfig {
 }
 
 function siteBaseURL({ protocol = 'http', port = 3000 }: URLConfig = {}) {
+  if (process.env?.NEXT_PUBLIC_SERVER) return process.env.NEXT_PUBLIC_SERVER;
   if (process.env?.NEXT_PUBLIC_VERCEL_URL) return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`;
   if (process.env?.NEXT_PUBLIC_SITE_URL) return process.env.NEXT_PUBLIC_SITE_URL;
   return `${protocol}://localhost:${port}`;


### PR DESCRIPTION
## Motivation

## Proposed Changes
- 뉴스상세: 관심 심볼 추가하기의 심볼 클릭해서 api 통신 시 로딩 ui 보여지도록 수정
- 심볼, 카테고리 chip: props로 전달한 selected 값으로 체크 UI를 제어하는 컨트롤 방식으로 수정
- 회원가입 폼에서 심볼 카테고리 추가 시 실제 추가는 되었지만 갱신되지 않은 캐시데이터로 인해, 관심 데이터가 없는 것처럼 데이터가 전달된 현상 개선(회원가입 폼에서 추가시 관련 리액트 쿼리의 쿼리데이터 갱신)

## To Reviewers
