### PR TITLE
fix: refresh api 에러 핸들링

### DIFF
--- a/src/service/axios.ts
+++ b/src/service/axios.ts
@@ -47,9 +47,11 @@ function createAxiosInstance() {
                 const refreshResponse = await requestAccessToken();
 
                 const accessToken = refreshResponse.headers['authorization'];
-                console.log('refreshResponse: ', refreshResponse);
+
+                console.log('[success] refreshResponse: ', refreshResponse);
+
                 if (accessToken) {
-                  console.log('refreshToken: ', accessToken);
+                  console.log('refresh AccessToken: ', accessToken);
                   await setCookie('accessToken', (accessToken as string).replace('Bearer ', ''), {
                     maxAge: 60 * 60,
                     path: '/',
@@ -58,12 +60,22 @@ function createAxiosInstance() {
 
                 return axiosInstance(config!);
               } catch (error) {
-                console.log('[refreshError] ', { error });
                 if (error instanceof AxiosError) {
                   const { response } = error as AxiosError<APIResponse>;
 
-                  console.log('refresh res data: ', response?.data);
+                  console.log('[refreshErrorRequest] ', response?.request['_header']);
+                  console.log('[refreshErrorResponsePayload] ', response?.data);
+
+                  if (response) {
+                    response.data = {
+                      status: HttpStatusCode.Unauthorized,
+                      msg: 'refresh token api fail',
+                    };
+
+                    throw error;
+                  }
                 }
+
                 throw error;
               }
             }


### PR DESCRIPTION
refresh api에서 에러 응답이 온 경우
401에러로 처리 될 수 있도록 intercept 처리
(백엔드에서 설정하는 refreshToken 쿠키가
백엔드 요청 헤더에 포함되지 않는
문제가 해결되기 전까지는,
자동로그인은 할 수 없음)

## Motivation
## Proposed Changes
## To Reviewers
